### PR TITLE
Convert demo notebook to SCI

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,5 @@
 {:config-in-call
- ;; for now ignore everything. TODO get this form to emit only cljs, no clj.
+ ;; for now ignore everything. TODO get this form to emit only cljs, no clj?
  {jsxgraph.clerk-ui/cljs
   {:linters {:unresolved-symbol {:level :off}
              :unresolved-namespace {:level :off}}}}}

--- a/dev/jsxgraph/clerk_ui.cljc
+++ b/dev/jsxgraph/clerk_ui.cljc
@@ -1,10 +1,10 @@
-(ns ^:nextjournal.clerk/no-cache jsxgraph.clerk-ui
-  (:require [applied-science.js-interop]
-            [clojure.string]
+(ns jsxgraph.clerk-ui
+  (:require #?(:cljs [jsxgraph.core])
             #?(:clj [nextjournal.clerk :as clerk])
-            #?(:clj [nextjournal.clerk.viewer :as viewer]))
+            #?(:cljs [nextjournal.clerk.sci-viewer :as sv])
+            #?(:cljs [sci.core :as sci]))
   #?(:cljs
-     (:require-macros jsxgraph.clerk-ui)))
+     (:require-macros [jsxgraph.clerk-ui])))
 
 ;; ## Clerk ClojureScript/Reagent viewer
 ;;
@@ -13,30 +13,26 @@
 ;; our API is a `hiccup` macro which will compile the contents as ClojureScript
 ;; and render it using Reagent.
 
-#?(:clj
-   (def reagent-viewer
-     (viewer/process-render-fn
-      {:transform-fn clerk/mark-presented
-       :render-fn '(fn render-var [{var :reagent/var}]
-                     (let [path (->> (clojure.string/split (str var) #"[./]")
-                                     (mapv munge))
-                           reagent-fn (applied-science.js-interop/get-in js/window path)
-                           wrapper (fn [f]
-                                     (let [result (f)]
-                                       (if (vector? result)
-                                         result
-                                         [v/inspect result])))]
-                       (when reagent-fn
-                         (v/html [:div.my-1 [wrapper reagent-fn]]))))})))
+#?(:cljs
+   (do (sci/require-cljs-analyzer-api)
+       (swap! sv/!sci-ctx
+              sci/merge-opts
+              {:namespaces
+               {'jsxgraph.core
+                (sci/copy-ns jsxgraph.core (sci/create-ns 'jsxgraph.core))}
+               :classes {'Math js/Math}
+               :aliases {'jsx 'jsxgraph.core}})))
 
-(defmacro cljs
-  "Evaluate expressions in ClojureScript instead of Clojure. If the result is
-   a vector, it is passed to Reagent and interpreted as hiccup."
-  [& exprs]
-  (let [name (symbol (str "reagent-view-" (hash exprs)))]
-    (if (:ns &env)
-      ;; in ClojureScript, define a function
-      `(defn ~(with-meta name {:export true}) [] ~@exprs)
-      ;; in Clojure, return a map with a reference to the fully qualified sym
-      `(nextjournal.clerk/with-viewer jsxgraph.clerk-ui/reagent-viewer
-         {:reagent/var '~(symbol (str *ns*) (str name))}))))
+#?(:clj
+   (defmacro cljs [& exprs]
+     `(nextjournal.clerk/with-viewer
+        {:transform-fn nextjournal.clerk/mark-presented
+         :render-fn '(fn [_#]
+                       (let [result# (do ~@exprs)]
+                         (js/console.log (pr-str result#))
+                         (js/console.log (pr-str '~exprs))
+                         (v/html
+                          (if (vector? result#)
+                            result#
+                            [v/inspect result#]))))}
+        {})))

--- a/dev/jsxgraph/clerk_ui.cljc
+++ b/dev/jsxgraph/clerk_ui.cljc
@@ -29,8 +29,6 @@
         {:transform-fn nextjournal.clerk/mark-presented
          :render-fn '(fn [_#]
                        (let [result# (do ~@exprs)]
-                         (js/console.log (pr-str result#))
-                         (js/console.log (pr-str '~exprs))
                          (v/html
                           (if (vector? result#)
                             result#

--- a/dev/jsxgraph/notebook.clj
+++ b/dev/jsxgraph/notebook.clj
@@ -66,7 +66,6 @@
 
 ;; And the example:
 
-
 (cljs
  (reagent/with-let
    [init         @!state

--- a/dev/jsxgraph/notebook.clj
+++ b/dev/jsxgraph/notebook.clj
@@ -96,3 +96,5 @@
 
      [jsx/FunctionGraph [sin startf endf]]
      [jsx/RiemannSum    [sin nf "left" startf endf]]]]))
+
+;; More coming!

--- a/dev/jsxgraph/notebook.clj
+++ b/dev/jsxgraph/notebook.clj
@@ -26,9 +26,7 @@
 
 ^#:nextjournal.clerk{:toc true :no-cache true :visibility :hide-ns}
 (ns jsxgraph.notebook
-  (:require #?(:cljs [jsxgraph.core :as jsx])
-            #?(:cljs [reagent.core :as reagent])
-            [jsxgraph.clerk-ui :as ui :refer [cljs]]))
+  (:require [jsxgraph.clerk-ui :refer [cljs]]))
 
 ;; ## Lines
 
@@ -61,29 +59,29 @@
 ;; This demo shows how to get the input talking to some state. There are issues
 ;; here that I'll document soon.
 
-#?(:cljs
-   (defonce !state
-     (reagent/atom
-      {:start -3 :end (* 2 Math/PI) :n 10})))
+(cljs
+ (defonce !state
+   (reagent/atom
+    {:start -3 :end (* 2 Math/PI) :n 10})))
 
 ;; And the example:
 
+
 (cljs
  (reagent/with-let
-   [init @!state
-    start-update (fn [s] (swap! !state assoc :start (.Value s)))
-    end-update (fn [s] (swap! !state assoc :end (.Value s)))
-    n-update (fn [s] (swap! !state assoc :n (.Value s)))
-    nf     #(:n @!state)
-    startf #(:start @!state)
-    endf   #(:end @!state)
-    sin    (fn [x] (Math/sin x))]
+   [init         @!state
+    start-update #(swap! !state assoc :start (.Value %))
+    end-update   #(swap! !state assoc :end (.Value %))
+    n-update     #(swap! !state assoc :n (.Value %))
+    nf           #(:n @!state)
+    startf       #(:start @!state)
+    endf         #(:end @!state)
+    sin          #(Math/sin %)]
    [:<>
     [:pre (str @!state)]
     [jsx/JSXGraph {:boundingbox [-8 4 8 -5]
                    :showCopyright false
                    :axis true}
-
      [jsx/Slider {:name "start"
                   :on-drag start-update}
       [[1 3.5] [5 3.5] [-10 (:start init) 0]]]
@@ -97,8 +95,5 @@
                   :on-drag n-update}
       [[1 1.5] [5 1.5] [1 (:n init) 50]]]
 
-
      [jsx/FunctionGraph [sin startf endf]]
      [jsx/RiemannSum    [sin nf "left" startf endf]]]]))
-
-;; More coming!

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -8,7 +8,7 @@
            [nextjournal.clerk.static-app
             nextjournal.viewer.notebook
             nextjournal.clerk.sci-viewer
-            jsxgraph.notebook]}}
+            jsxgraph.clerk-ui]}}
    :output-dir "public/js"
    :asset-path "/js"
    :build-options {:cache-level :off}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -11,12 +11,9 @@
             jsxgraph.clerk-ui]}}
    :output-dir "public/js"
    :asset-path "/js"
-   :build-options {:cache-level :off}
    :compiler-options
-
    {:infer-externs :auto
-    :optimizations :advanced
-    :source-map true}}
+    :optimizations :advanced}}
 
   :stories
   {:target :npm-module


### PR DESCRIPTION
This PR converts the published demo notebook to use SCI for the inline examples. This makes the notebook feel more like a Clerk notebook, other than the extra namespaces that are available in the SCI context. 

This should also fix caching issues in the published code, since changes to the notebook won't change the js bundle.