### PR TITLE
Fix JS path, GIT_SHA replacements for Garden, document tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [unreleased]
 
+- #29:
+
+  - Fixes `user.clj` and `bb.edn` to work with Garden.
+  - Adds docstrings to all `bb tasks`. Run `bb tasks` to see these.
+
 - #24:
 
   - Upgrade to the latest Clerk version. This pulls us along to React v18.

--- a/bb.edn
+++ b/bb.edn
@@ -1,34 +1,46 @@
 {:tasks
  {dev-notebook
-  (do (shell "npm install")
-      (shell "npm run watch-clerk"))
+  {:doc "Start a shadow-cljs watch process that generates this project's custom JS."
+   :task
+   (do (shell "npm install")
+       (shell "npm run watch-clerk"))}
 
   start-clerk
-  (shell "clojure -X:dev:nextjournal/clerk user/start!")
+  {:doc "Start a Clerk dev server configured with this project's custom JS."
+   :task
+   (shell "clojure -X:dev:nextjournal/clerk user/start!")}
 
   publish-gh-pages
-  (do (shell "npm ci")
-      (shell "npm run release-clerk")
-      (apply shell
-             "clojure -X:dev:nextjournal/clerk user/github-pages!"
-             *command-line-args*)
-      (spit "./public/CNAME" "jsxgraph.mentat.org")
+  {:doc "Generate a fresh static build and start a local webserver."
+   :task
+   (do (shell "npm ci")
+       (shell "npm run release-clerk")
+       (apply shell
+              "clojure -X:dev:nextjournal/clerk user/static-build!"
+              *command-line-args*)
+       (spit "./public/CNAME" "jsxgraph.mentat.org")
 
-      ;; This is necessary for folders with underscores to work, like the one
-      ;; that Clerk uses to store data for its CAS.
-      (spit "./public/.nojekyll" ""))
+       ;; This is necessary for folders with underscores to work, like the one
+       ;; that Clerk uses to store data for its CAS.
+       (spit "./public/.nojekyll" ""))}
 
   release-gh-pages
-  (do (shell "rm -rf public")
-      (run 'publish-gh-pages)
-      (shell "npm run gh-pages"))
+  {:doc "Generate a fresh static build and release it to Github Pages."
+   :task
+   (do (shell "rm -rf public")
+       (run 'publish-gh-pages)
+       (shell "npm run gh-pages"))}
 
   publish-local
-  (do (run 'publish-gh-pages)
-      (shell "npm run serve"))
+  {:doc "Generate a fresh static build in the `public` folder."
+   :task
+   (do (run 'publish-gh-pages)
+       (shell "npm run serve"))}
 
   release
-  (shell "clojure -T:build publish")
+  {:doc "Release the library to Clojars."
+   :task (shell "clojure -T:build publish")}
 
   lint
-  (shell "clj-kondo --lint src:dev")}}
+  {:doc "Lint the src and dev directories with clj-kondo."
+   :task (shell "clj-kondo --lint src:dev")}}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,14 +1,5 @@
 {:tasks
- {sha
-  (let [sha (-> (shell {:out :string} "git rev-parse HEAD")
-                (:out)
-                (clojure.string/trim))
-        file "public/index.html"]
-    (-> (slurp file)
-        (clojure.string/replace "$GIT_SHA" sha)
-        (->> (spit file))))
-
-  dev-notebook
+ {dev-notebook
   (do (shell "npm install")
       (shell "npm run watch-clerk"))
 
@@ -18,8 +9,9 @@
   publish-gh-pages
   (do (shell "npm ci")
       (shell "npm run release-clerk")
-      (shell "clojure -X:dev:nextjournal/clerk user/github-pages!")
-      (run 'sha)
+      (apply shell
+             "clojure -X:dev:nextjournal/clerk user/github-pages!"
+             *command-line-args*)
       (spit "./public/CNAME" "jsxgraph.mentat.org")
 
       ;; This is necessary for folders with underscores to work, like the one

--- a/deps.edn
+++ b/deps.edn
@@ -18,7 +18,9 @@
      :git/sha "75f073c4899e37b2259cb2057cbf863b90892897"
      :deps/root "render"}
     org.mentat/clerk-utils {:mvn/version "0.0.1"}}
-   :exec-fn user/garden!}
+   :exec-fn user/garden!
+   :exec-args
+   {:cas-prefix "/mentat-collective/jsxgraph.cljs/commit/$GIT_SHA/"}}
 
   :build
   {:deps {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}

--- a/deps.edn
+++ b/deps.edn
@@ -18,9 +18,7 @@
      :git/sha "75f073c4899e37b2259cb2057cbf863b90892897"
      :deps/root "render"}
     org.mentat/clerk-utils {:mvn/version "0.0.1"}}
-   :exec-fn user/garden!
-   :exec-args
-   {:cas-prefix "/mentat-collective/jsxgraph.cljs/commit/$GIT_SHA/"}}
+   :exec-fn user/garden!}
 
   :build
   {:deps {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -28,6 +28,7 @@
         cas (cv/store+get-cas-url!
              {:out-path (str out-path "/js") :ext "js"}
              (fs/read-all-bytes "public/js/main.js"))]
+    ;; TODO make a change here so we don't have an invalid absolute path on garden.
     (swap! config/!resource->url assoc "/js/viewer.js" (str "/js/" cas))
     (clerk/build!
      (merge {:index index}


### PR DESCRIPTION
From the CHANGELOG:

- #29:

  - Fixes `user.clj` and `bb.edn` to work with Garden.
  - Adds docstrings to all `bb tasks`. Run `bb tasks` to see these.