### PR TITLE
Use babashka pod for clj-kondo vs JVM

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,5 +1,7 @@
-{:tasks
- {dev-notebook
+{:pods {clj-kondo/clj-kondo {:version "2022.12.10"}}
+ :tasks
+ {:requires ([pod.borkdude.clj-kondo :as clj-kondo])
+  dev-notebook
   {:doc "Start a shadow-cljs watch process that generates this project's custom JS."
    :task
    (do (shell "npm install")
@@ -44,4 +46,5 @@
 
   lint
   {:doc "Lint the src and dev directories with clj-kondo."
-   :task (shell "clj-kondo --lint src:dev")}}}
+   :task (clj-kondo/print!
+          (clj-kondo/run! {:lint ["src" "dev"]}))}}}

--- a/deps.edn
+++ b/deps.edn
@@ -23,9 +23,4 @@
   :build
   {:deps {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}
           slipset/deps-deploy {:mvn/version "0.2.0"}}
-   :ns-default build}
-
-  :lint
-  ;; Invoke with clj -M:dev:lint --lint src
-  {:main-opts ["-m" "clj-kondo.main"]
-   :replace-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}}}}
+   :ns-default build}}}

--- a/src/jsxgraph/core.cljs
+++ b/src/jsxgraph/core.cljs
@@ -93,7 +93,7 @@ to provide any element in `<children>` with access to the bound `board` instance
                (fn unmount []
                  (when board (.removeObject board item))
                  (when ref (ref nil))))
-             (fn []))))
+             js/undefined)))
         nil)))))
 
 ;; ## Elements


### PR DESCRIPTION
For slighty faster startup time and a cleaner deps.edn.