### PR TITLE
Remove this-as, prepare for portal viewer

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,29 +10,28 @@ jobs:
     steps:
       - uses: actions/cache@v3
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/deps.edn') }}
-          restore-keys: ${{ runner.os }}-m2
+            path: |
+              .cpcache
+              .shadow-cljs
+              ~/.m2
+            key: "1"
 
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@4.0
+        uses: DeLaGuardo/setup-clojure@master
         with:
           cli: latest
+          bb: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install babashka
-        uses: just-sultanov/setup-babashka@v2
-        with:
-          version: '0.8.156'
 
       - name: Build static site
         run: bb build-static
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public/build

--- a/.github/workflows/kondo.yml
+++ b/.github/workflows/kondo.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install babashka
-        uses: just-sultanov/setup-babashka@v2
+      - name: Install Babashka
+        uses: DeLaGuardo/setup-clojure@10.2
         with:
-          version: '0.8.156'
+          bb: latest
 
       - name: Cache kondo directory
         uses: actions/cache@v2
@@ -24,5 +24,8 @@ jobs:
           key: ${{ runner.os }}-kondo
           restore-keys: ${{ runner.os }}-kondo
 
-      - name: Run clj-kondo
+      - name: Lint dependencies
+        run: bb lint-deps
+
+      - name: Lint project files
         run: bb lint --config '{:output {:pattern "::{{level}} file={{filename}},line={{row}},col={{col}}::{{message}}"}}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [unreleased]
 
+## [0.2.1]
+
+- #34:
+
+  - removes SCI-incompatible code from `jsxgraph.core` to allow JSXGraph.cljs
+    use from Portal.
+
+  - upgrades pieces of the local build (Clerk, kondo etc)
+
 ## [0.2.0]
 
 - #32:

--- a/bb.edn
+++ b/bb.edn
@@ -1,9 +1,9 @@
 {:deps {org.babashka/http-server {:mvn/version "0.1.11"}
-        org.babashka/cli {:mvn/version "0.2.23"}}
- :pods {clj-kondo/clj-kondo {:version "2023.01.20"}}
+        org.babashka/cli {:mvn/version "0.2.23"}
+        io.github.clj-kondo/clj-kondo-bb
+        {:git/tag "v2023.01.20" :git/sha "adfc7df"}}
  :tasks
- {:requires ([babashka.cli :as cli]
-             [pod.borkdude.clj-kondo :as clj-kondo])
+ {:requires ([babashka.cli :as cli])
   :init
   (do (def cli-opts
         (cli/parse-opts *command-line-args* {:coerce {:port :int}}))
@@ -51,7 +51,16 @@
   {:doc "Release the library to Clojars."
    :task (shell "clojure -T:build publish")}
 
+  lint-deps
+  {:requires ([clj-kondo.core :as kondo])
+   :doc "Lint dependencies."
+   :task (kondo/run!
+          {:lint [(with-out-str
+                    (babashka.tasks/clojure
+                     "-Spath -A:nextjournal/clerk"))]
+           :dependencies true})}
+
   lint
   {:doc "Lint the src and dev directories with clj-kondo."
-   :task (clj-kondo/print!
-          (clj-kondo/run! {:lint ["src" "dev"]}))}}}
+   :task (exec 'clj-kondo.core/exec)
+   :exec-args {:lint ["src" "dev"]}}}}

--- a/build.clj
+++ b/build.clj
@@ -17,7 +17,7 @@
 ;; ## Variables
 
 (def lib 'org.mentat/jsxgraph.cljs)
-(def version "0.2.0")
+(def version "0.2.1")
 (def pom-deps
   {'org.babashka/sci
    {:mvn/version "0.6.37"

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {reagent/reagent {:mvn/version "1.1.1"}}
+ :deps {reagent/reagent {:mvn/version "1.2.0"}}
 
  :aliases
  {:nextjournal/clerk
@@ -7,17 +7,17 @@
    :extra-deps
    {org.clojure/clojure       {:mvn/version "1.11.1"}
     org.clojure/clojurescript {:mvn/version "1.11.60"}
-    org.mentat/clerk-utils    {:mvn/version "0.4.1"}
+    org.mentat/clerk-utils    {:mvn/version "0.6.0"}
 
     io.github.nextjournal/clerk
-    {:git/sha "fad499407d979916d21b33cc7e46e73f7a485e37"}
+    {:git/sha "1f6c5331418aaf9c5a4335fc2e6e95f07dc3af6b"}
     io.github.nextjournal/clerk.render
     {:git/url "https://github.com/nextjournal/clerk"
-     :git/sha "fad499407d979916d21b33cc7e46e73f7a485e37"
+     :git/sha "1f6c5331418aaf9c5a4335fc2e6e95f07dc3af6b"
      :deps/root "render"}}
    :exec-fn user/build!}
 
   :build
-  {:deps {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}
+  {:deps {io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}
           slipset/deps-deploy {:mvn/version "0.2.0"}}
    :ns-default build}}}

--- a/dev/jsxgraph/notebook.clj
+++ b/dev/jsxgraph/notebook.clj
@@ -1,8 +1,6 @@
-^#:nextjournal.clerk
-{:toc true
- :no-cache true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns jsxgraph.notebook
+  #:nextjournal.clerk{:toc true :no-cache true}
   (:require [mentat.clerk-utils.docs :as docs]
             [mentat.clerk-utils.show :refer [show-sci]]
             [nextjournal.clerk :as clerk]))
@@ -10,8 +8,8 @@
 ^{::clerk/visibility {:code :hide :result :hide}}
 (clerk/eval-cljs
  ;; These aliases only apply inside this namespace.
- '(require '[jsxgraph.core :as jsx])
- '(require '[reagent.core :as reagent]))
+ '(do (require '[jsxgraph.core :as jsx])
+      (require '[reagent.core :as reagent])))
 
 ;; # JSXGraph.cljs
 ;;
@@ -339,6 +337,7 @@
  (reagent/with-let
    [!state  (reagent/atom {:x 0 :y 0})
     update! (fn [p]
+              (js/console.log p)
               (swap! !state assoc
                      :x (.X p)
                      :y (.Y p)))]

--- a/dev/jsxgraph/notebook.clj
+++ b/dev/jsxgraph/notebook.clj
@@ -337,7 +337,6 @@
  (reagent/with-let
    [!state  (reagent/atom {:x 0 :y 0})
     update! (fn [p]
-              (js/console.log p)
               (swap! !state assoc
                      :x (.X p)
                      :y (.Y p)))]

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,18 +6,18 @@
   "packages": {
     "": {
       "dependencies": {
-        "@codemirror/autocomplete": "6.4.1",
-        "@codemirror/commands": "6.2.1",
+        "@codemirror/autocomplete": "6.7.1",
+        "@codemirror/commands": "6.2.4",
         "@codemirror/lang-markdown": "6.0.0",
-        "@codemirror/language": "6.6.0",
-        "@codemirror/lint": "6.1.1",
-        "@codemirror/search": "6.2.3",
-        "@codemirror/state": "6.2.0",
-        "@codemirror/view": "6.9.0",
-        "@lezer/common": "1.0.2",
-        "@lezer/generator": "1.2.2",
-        "@lezer/highlight": "1.1.3",
-        "@lezer/lr": "1.3.3",
+        "@codemirror/language": "6.7.0",
+        "@codemirror/lint": "6.2.2",
+        "@codemirror/search": "6.5.0",
+        "@codemirror/state": "6.2.1",
+        "@codemirror/view": "6.13.0",
+        "@lezer/common": "1.0.3",
+        "@lezer/generator": "1.2.3",
+        "@lezer/highlight": "1.1.6",
+        "@lezer/lr": "1.3.6",
         "@lezer/markdown": "1.0.2",
         "@nextjournal/lang-clojure": "1.0.0",
         "@nextjournal/lezer-clojure": "1.0.0",
@@ -33,19 +33,19 @@
         "punycode": "2.1.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "shadow-cljs": "2.20.14",
+        "shadow-cljs": "2.23.1",
         "use-sync-external-store": "1.2.0",
         "vh-sticky-table-header": "1.2.1",
-        "w3c-keyname": "2.2.6"
+        "w3c-keyname": "2.2.8"
       },
       "devDependencies": {
         "gh-pages": "^3.2.3"
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.1.tgz",
-      "integrity": "sha512-06yAmj0FjPZzYOpNeugJtG28GNqU2/CPr34m91Q+fKSyTOR6+hDFiatkPcIkxOlU0K5yP7WH6KoLg3fTqIUgaw==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.7.1.tgz",
+      "integrity": "sha512-hSxf9S0uB+GV+gBsjY1FZNo53e1FFdzPceRfCfD1gWOnV6o21GfB5J5Wg9G/4h76XZMPrF0A6OCK/Rz5+V1egg==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.1.tgz",
-      "integrity": "sha512-FFiNKGuHA5O8uC6IJE5apI5rT9gyjlw4whqy4vlcX0wE/myxL6P1s0upwDhY4HtMWLOwzwsp0ap3bjdQhvfDOA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.4.tgz",
+      "integrity": "sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -71,20 +71,21 @@
       }
     },
     "node_modules/@codemirror/lang-css": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.0.2.tgz",
-      "integrity": "sha512-4V4zmUOl2Glx0GWw0HiO1oGD4zvMlIQ3zx5hXOE6ipCjhohig2bhWRAasrZylH9pRNTcl1VMa59Lsl8lZWlTzw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.2.0.tgz",
+      "integrity": "sha512-oyIdJM29AyRPM3+PPq1I2oIk8NpUfEN3kAM05XWDDs6o3gSneIKaVJifT2P+fqONLou2uIgXynFyMUDQvo/szA==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
         "@lezer/css": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-html": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.2.tgz",
-      "integrity": "sha512-bqCBASkteKySwtIbiV/WCtGnn/khLRbbiV5TE+d9S9eQJD7BA4c5dTRm2b3bVmSpilff5EYxvB4PQaZzM/7cNw==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.4.tgz",
+      "integrity": "sha512-NbrqEp0GUOSvhZbG6BxVcS4SzM4SvN5vkkD2sEoETHIyHLZDb9pO1z+r1L2heb6LuF4bUeBCXKjHXoSeDJHO1w==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/lang-css": "^6.0.0",
@@ -98,9 +99,9 @@
       }
     },
     "node_modules/@codemirror/lang-javascript": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.4.tgz",
-      "integrity": "sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==",
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.9.tgz",
+      "integrity": "sha512-z3jdkcqOEBT2txn2a87A0jSy6Te3679wg/U8QzMeftFt+4KA6QooMwfdFzJiuC3L6fXKfTXZcDocoaxMYfGz0w==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.6.0",
@@ -125,9 +126,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.6.0.tgz",
-      "integrity": "sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.7.0.tgz",
+      "integrity": "sha512-4SMwe6Fwn57klCUsVN0y4/h/iWT+XIXFEmop2lIHHuWO0ubjCrF3suqSZLyOQlznxkNnNbOOfKe5HQbQGCAmTg==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -138,9 +139,9 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.1.1.tgz",
-      "integrity": "sha512-e+M543x0NVHGayNHQzLP4XByJsvbu/ojY6+0VF2Y4Uu66Rt1nADuxNflZwECLf7gS009smIsptSUa6bUj/U/rw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.2.2.tgz",
+      "integrity": "sha512-kHGuynBHjqinp1Bx25D2hgH8a6Fh1m9rSmZFzBVTqPIXDIcZ6j3VI67DY8USGYpGrjrJys9R52eLxtfERGNozg==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -148,9 +149,9 @@
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.3.tgz",
-      "integrity": "sha512-V9n9233lopQhB1dyjsBK2Wc1i+8hcCqxl1wQ46c5HWWLePoe4FluV3TGHoZ04rBRlGjNyz9DTmpJErig8UE4jw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.0.tgz",
+      "integrity": "sha512-64/M40YeJPToKvGO6p3fijo2vwUEj4nACEAXElCaYQ50HrXSvRaK+NHEhSh73WFBGdvIdhrV+lL9PdJy2RfCYA==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -158,14 +159,14 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.0.tgz",
-      "integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
+      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
     },
     "node_modules/@codemirror/view": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.9.0.tgz",
-      "integrity": "sha512-uFaqE6fBOp0Dj/tmWoe/TFlSSIPdpAzhvATgbq1eAKRkgq3hY79FioZ7nfdiT+24kz68AIWuSZ9hi3psKe36WQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.13.0.tgz",
+      "integrity": "sha512-oXTfJzHJ5Tl7f6T8ZO0HKf981zubxgKohjddLobbntbNZHlOZGMRL+pPZGtclDWFaFJWtGBYRGyNdjQ6Xsx5yA==",
       "dependencies": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",
@@ -188,23 +189,23 @@
       "optional": true
     },
     "node_modules/@lezer/common": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.2.tgz",
-      "integrity": "sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.3.tgz",
+      "integrity": "sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA=="
     },
     "node_modules/@lezer/css": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.1.tgz",
-      "integrity": "sha512-mSjx+unLLapEqdOYDejnGBokB5+AiJKZVclmud0MKQOKx3DLJ5b5VTCstgDDknR6iIV4gVrN6euzsCnj0A2gQA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.2.tgz",
+      "integrity": "sha512-5TKMAReXukfEmIiZprDlGfZVfOOCyEStFi1YLzxclm9H3G/HHI49/2wzlRT6bQw5r7PoZVEtjTItEkb/UuZQyg==",
       "dependencies": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/generator": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@lezer/generator/-/generator-1.2.2.tgz",
-      "integrity": "sha512-O//eH9jTPM1GnbZruuD23xU68Pkuragonn1DEIom4Kt/eJN/QFt7Vzvp1YjV/XBmoUKC+2ySPgrA5fMF9FMM2g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/generator/-/generator-1.2.3.tgz",
+      "integrity": "sha512-xRmNryYbJpWs7novjWtQLCGHOj71B4X1QHQ4SgJqwm11tl6COEVAGhuFTXKX16JMJUhumdXaX8We6hEMd4clDg==",
       "dependencies": {
         "@lezer/common": "^1.0.2",
         "@lezer/lr": "^1.3.0"
@@ -214,17 +215,17 @@
       }
     },
     "node_modules/@lezer/highlight": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.3.tgz",
-      "integrity": "sha512-3vLKLPThO4td43lYRBygmMY18JN3CPh9w+XS2j8WC30vR4yZeFG4z1iFe4jXE43NtGqe//zHW5q8ENLlHvz9gw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
+      "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@lezer/html": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.2.tgz",
-      "integrity": "sha512-LKGyDdqqDugXR/lKM9FwaKEfMerbZ/aqvhLf0P1FLLK/pVP7wKHXGcg6g3cJ7ckvFidn0tXA8jioG0irVsCBAQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.4.tgz",
+      "integrity": "sha512-HdJYMVZcT4YsMo7lW3ipL4NoyS2T67kMPuSVS5TgLGqmaCjEU/D6xv7zsa1ktvTK5lwk7zzF1e3eU6gBZIPm5g==",
       "dependencies": {
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0",
@@ -232,18 +233,18 @@
       }
     },
     "node_modules/@lezer/javascript": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.1.tgz",
-      "integrity": "sha512-Hqx36DJeYhKtdpc7wBYPR0XF56ZzIp0IkMO/zNNj80xcaFOV4Oj/P7TQc/8k2TxNhzl7tV5tXS8ZOCPbT4L3nA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.3.tgz",
+      "integrity": "sha512-k7Eo9z9B1supZ5cCD4ilQv/RZVN30eUQL+gGbr6ybrEY3avBAL5MDiYi2aa23Aj0A79ry4rJRvPAwE2TM8bd+A==",
       "dependencies": {
         "@lezer/highlight": "^1.1.3",
         "@lezer/lr": "^1.3.0"
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.3.tgz",
-      "integrity": "sha512-JPQe3mwJlzEVqy67iQiiGozhcngbO8QBgpqZM6oL1Wj/dXckrEexpBLeFkq0edtW5IqnPRFxA24BHJni8Js69w==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.6.tgz",
+      "integrity": "sha512-IDhcWjfxwWACnatUi0GzWBCbochfqxo3LZZlS27LbJh8RVYYXXyR5Ck9659IhkWkhSW/kZlaaiJpUO+YZTUK+Q==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -505,9 +506,9 @@
       }
     },
     "node_modules/browserify-sign/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -623,9 +624,9 @@
       }
     },
     "node_modules/crelt": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "node_modules/crypto-browserify": {
       "version": "3.12.0",
@@ -654,9 +655,9 @@
       "integrity": "sha512-XaNc2azaAwXhGjmCMtxlD+AowpMfLimVsAoTMpqrvb8CWoA4QqyV12mc4Ue6KSoDvfuS831tsumfhDYxGd4FGA=="
     },
     "node_modules/des.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -915,9 +916,9 @@
       }
     },
     "node_modules/hash-base/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1454,9 +1455,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1555,13 +1556,13 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "2.20.14",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.14.tgz",
-      "integrity": "sha512-ZwaPLsLoUgYAuuAlKnq1QMArrJzs05AB/yrpdVVLdpK2s7Kr8RX9+0pNfPuCjZDS4vVDCrTmJ5NpU2VoZWZRWQ==",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.23.1.tgz",
+      "integrity": "sha512-qPI8FyRSmOJgl24svvrWvA/29fA94CVo89X0v6B4eaH/uex5NBSBZqyw58Bo4ZBu0YUxEXnwB8BSHLgmAzf8LQ==",
       "dependencies": {
         "node-libs-browser": "^2.2.1",
         "readline-sync": "^1.4.7",
-        "shadow-cljs-jar": "1.3.2",
+        "shadow-cljs-jar": "1.3.4",
         "source-map-support": "^0.4.15",
         "which": "^1.3.1",
         "ws": "^7.4.6"
@@ -1574,9 +1575,9 @@
       }
     },
     "node_modules/shadow-cljs-jar": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz",
-      "integrity": "sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz",
+      "integrity": "sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA=="
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -1635,9 +1636,9 @@
       }
     },
     "node_modules/style-mod": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
+      "integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw=="
     },
     "node_modules/style-value-types": {
       "version": "5.0.0",
@@ -1676,9 +1677,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
@@ -1749,9 +1750,9 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "node_modules/w3c-keyname": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
-      "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg=="
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "node_modules/which": {
       "version": "1.3.1",
@@ -1800,9 +1801,9 @@
   },
   "dependencies": {
     "@codemirror/autocomplete": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.1.tgz",
-      "integrity": "sha512-06yAmj0FjPZzYOpNeugJtG28GNqU2/CPr34m91Q+fKSyTOR6+hDFiatkPcIkxOlU0K5yP7WH6KoLg3fTqIUgaw==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.7.1.tgz",
+      "integrity": "sha512-hSxf9S0uB+GV+gBsjY1FZNo53e1FFdzPceRfCfD1gWOnV6o21GfB5J5Wg9G/4h76XZMPrF0A6OCK/Rz5+V1egg==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -1811,9 +1812,9 @@
       }
     },
     "@codemirror/commands": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.1.tgz",
-      "integrity": "sha512-FFiNKGuHA5O8uC6IJE5apI5rT9gyjlw4whqy4vlcX0wE/myxL6P1s0upwDhY4HtMWLOwzwsp0ap3bjdQhvfDOA==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.4.tgz",
+      "integrity": "sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -1822,20 +1823,21 @@
       }
     },
     "@codemirror/lang-css": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.0.2.tgz",
-      "integrity": "sha512-4V4zmUOl2Glx0GWw0HiO1oGD4zvMlIQ3zx5hXOE6ipCjhohig2bhWRAasrZylH9pRNTcl1VMa59Lsl8lZWlTzw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.2.0.tgz",
+      "integrity": "sha512-oyIdJM29AyRPM3+PPq1I2oIk8NpUfEN3kAM05XWDDs6o3gSneIKaVJifT2P+fqONLou2uIgXynFyMUDQvo/szA==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
         "@lezer/css": "^1.0.0"
       }
     },
     "@codemirror/lang-html": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.2.tgz",
-      "integrity": "sha512-bqCBASkteKySwtIbiV/WCtGnn/khLRbbiV5TE+d9S9eQJD7BA4c5dTRm2b3bVmSpilff5EYxvB4PQaZzM/7cNw==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.4.tgz",
+      "integrity": "sha512-NbrqEp0GUOSvhZbG6BxVcS4SzM4SvN5vkkD2sEoETHIyHLZDb9pO1z+r1L2heb6LuF4bUeBCXKjHXoSeDJHO1w==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/lang-css": "^6.0.0",
@@ -1849,9 +1851,9 @@
       }
     },
     "@codemirror/lang-javascript": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.4.tgz",
-      "integrity": "sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==",
+      "version": "6.1.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.9.tgz",
+      "integrity": "sha512-z3jdkcqOEBT2txn2a87A0jSy6Te3679wg/U8QzMeftFt+4KA6QooMwfdFzJiuC3L6fXKfTXZcDocoaxMYfGz0w==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.6.0",
@@ -1876,9 +1878,9 @@
       }
     },
     "@codemirror/language": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.6.0.tgz",
-      "integrity": "sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.7.0.tgz",
+      "integrity": "sha512-4SMwe6Fwn57klCUsVN0y4/h/iWT+XIXFEmop2lIHHuWO0ubjCrF3suqSZLyOQlznxkNnNbOOfKe5HQbQGCAmTg==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -1889,9 +1891,9 @@
       }
     },
     "@codemirror/lint": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.1.1.tgz",
-      "integrity": "sha512-e+M543x0NVHGayNHQzLP4XByJsvbu/ojY6+0VF2Y4Uu66Rt1nADuxNflZwECLf7gS009smIsptSUa6bUj/U/rw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.2.2.tgz",
+      "integrity": "sha512-kHGuynBHjqinp1Bx25D2hgH8a6Fh1m9rSmZFzBVTqPIXDIcZ6j3VI67DY8USGYpGrjrJys9R52eLxtfERGNozg==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -1899,9 +1901,9 @@
       }
     },
     "@codemirror/search": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.3.tgz",
-      "integrity": "sha512-V9n9233lopQhB1dyjsBK2Wc1i+8hcCqxl1wQ46c5HWWLePoe4FluV3TGHoZ04rBRlGjNyz9DTmpJErig8UE4jw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.0.tgz",
+      "integrity": "sha512-64/M40YeJPToKvGO6p3fijo2vwUEj4nACEAXElCaYQ50HrXSvRaK+NHEhSh73WFBGdvIdhrV+lL9PdJy2RfCYA==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -1909,14 +1911,14 @@
       }
     },
     "@codemirror/state": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.0.tgz",
-      "integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
+      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
     },
     "@codemirror/view": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.9.0.tgz",
-      "integrity": "sha512-uFaqE6fBOp0Dj/tmWoe/TFlSSIPdpAzhvATgbq1eAKRkgq3hY79FioZ7nfdiT+24kz68AIWuSZ9hi3psKe36WQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.13.0.tgz",
+      "integrity": "sha512-oXTfJzHJ5Tl7f6T8ZO0HKf981zubxgKohjddLobbntbNZHlOZGMRL+pPZGtclDWFaFJWtGBYRGyNdjQ6Xsx5yA==",
       "requires": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",
@@ -1939,40 +1941,40 @@
       "optional": true
     },
     "@lezer/common": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.2.tgz",
-      "integrity": "sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.3.tgz",
+      "integrity": "sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA=="
     },
     "@lezer/css": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.1.tgz",
-      "integrity": "sha512-mSjx+unLLapEqdOYDejnGBokB5+AiJKZVclmud0MKQOKx3DLJ5b5VTCstgDDknR6iIV4gVrN6euzsCnj0A2gQA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.2.tgz",
+      "integrity": "sha512-5TKMAReXukfEmIiZprDlGfZVfOOCyEStFi1YLzxclm9H3G/HHI49/2wzlRT6bQw5r7PoZVEtjTItEkb/UuZQyg==",
       "requires": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
       }
     },
     "@lezer/generator": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@lezer/generator/-/generator-1.2.2.tgz",
-      "integrity": "sha512-O//eH9jTPM1GnbZruuD23xU68Pkuragonn1DEIom4Kt/eJN/QFt7Vzvp1YjV/XBmoUKC+2ySPgrA5fMF9FMM2g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/generator/-/generator-1.2.3.tgz",
+      "integrity": "sha512-xRmNryYbJpWs7novjWtQLCGHOj71B4X1QHQ4SgJqwm11tl6COEVAGhuFTXKX16JMJUhumdXaX8We6hEMd4clDg==",
       "requires": {
         "@lezer/common": "^1.0.2",
         "@lezer/lr": "^1.3.0"
       }
     },
     "@lezer/highlight": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.3.tgz",
-      "integrity": "sha512-3vLKLPThO4td43lYRBygmMY18JN3CPh9w+XS2j8WC30vR4yZeFG4z1iFe4jXE43NtGqe//zHW5q8ENLlHvz9gw==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
+      "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
       "requires": {
         "@lezer/common": "^1.0.0"
       }
     },
     "@lezer/html": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.2.tgz",
-      "integrity": "sha512-LKGyDdqqDugXR/lKM9FwaKEfMerbZ/aqvhLf0P1FLLK/pVP7wKHXGcg6g3cJ7ckvFidn0tXA8jioG0irVsCBAQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.4.tgz",
+      "integrity": "sha512-HdJYMVZcT4YsMo7lW3ipL4NoyS2T67kMPuSVS5TgLGqmaCjEU/D6xv7zsa1ktvTK5lwk7zzF1e3eU6gBZIPm5g==",
       "requires": {
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0",
@@ -1980,18 +1982,18 @@
       }
     },
     "@lezer/javascript": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.1.tgz",
-      "integrity": "sha512-Hqx36DJeYhKtdpc7wBYPR0XF56ZzIp0IkMO/zNNj80xcaFOV4Oj/P7TQc/8k2TxNhzl7tV5tXS8ZOCPbT4L3nA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.3.tgz",
+      "integrity": "sha512-k7Eo9z9B1supZ5cCD4ilQv/RZVN30eUQL+gGbr6ybrEY3avBAL5MDiYi2aa23Aj0A79ry4rJRvPAwE2TM8bd+A==",
       "requires": {
         "@lezer/highlight": "^1.1.3",
         "@lezer/lr": "^1.3.0"
       }
     },
     "@lezer/lr": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.3.tgz",
-      "integrity": "sha512-JPQe3mwJlzEVqy67iQiiGozhcngbO8QBgpqZM6oL1Wj/dXckrEexpBLeFkq0edtW5IqnPRFxA24BHJni8Js69w==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.6.tgz",
+      "integrity": "sha512-IDhcWjfxwWACnatUi0GzWBCbochfqxo3LZZlS27LbJh8RVYYXXyR5Ck9659IhkWkhSW/kZlaaiJpUO+YZTUK+Q==",
       "requires": {
         "@lezer/common": "^1.0.0"
       }
@@ -2232,9 +2234,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -2348,9 +2350,9 @@
       }
     },
     "crelt": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -2376,9 +2378,9 @@
       "integrity": "sha512-XaNc2azaAwXhGjmCMtxlD+AowpMfLimVsAoTMpqrvb8CWoA4QqyV12mc4Ue6KSoDvfuS831tsumfhDYxGd4FGA=="
     },
     "des.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
-      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
       "requires": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -2570,9 +2572,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -3000,9 +3002,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3079,22 +3081,22 @@
       }
     },
     "shadow-cljs": {
-      "version": "2.20.14",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.14.tgz",
-      "integrity": "sha512-ZwaPLsLoUgYAuuAlKnq1QMArrJzs05AB/yrpdVVLdpK2s7Kr8RX9+0pNfPuCjZDS4vVDCrTmJ5NpU2VoZWZRWQ==",
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.23.1.tgz",
+      "integrity": "sha512-qPI8FyRSmOJgl24svvrWvA/29fA94CVo89X0v6B4eaH/uex5NBSBZqyw58Bo4ZBu0YUxEXnwB8BSHLgmAzf8LQ==",
       "requires": {
         "node-libs-browser": "^2.2.1",
         "readline-sync": "^1.4.7",
-        "shadow-cljs-jar": "1.3.2",
+        "shadow-cljs-jar": "1.3.4",
         "source-map-support": "^0.4.15",
         "which": "^1.3.1",
         "ws": "^7.4.6"
       }
     },
     "shadow-cljs-jar": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz",
-      "integrity": "sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz",
+      "integrity": "sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA=="
     },
     "source-map": {
       "version": "0.5.7",
@@ -3146,9 +3148,9 @@
       }
     },
     "style-mod": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.3.tgz",
+      "integrity": "sha512-78Jv8kYJdjbvRwwijtCevYADfsI0lGzYJe4mMFdceO8l75DFFDoqBhR1jVDicDRRaX4//g1u9wKeo+ztc2h1Rw=="
     },
     "style-value-types": {
       "version": "5.0.0",
@@ -3180,9 +3182,9 @@
       }
     },
     "tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -3251,9 +3253,9 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
     },
     "w3c-keyname": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
-      "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg=="
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -6,18 +6,18 @@
     "gh-pages": "gh-pages -d public/build --dotfiles true"
   },
   "dependencies": {
-    "@codemirror/autocomplete": "6.4.1",
-    "@codemirror/commands": "6.2.1",
+    "@codemirror/autocomplete": "6.7.1",
+    "@codemirror/commands": "6.2.4",
     "@codemirror/lang-markdown": "6.0.0",
-    "@codemirror/language": "6.6.0",
-    "@codemirror/lint": "6.1.1",
-    "@codemirror/search": "6.2.3",
-    "@codemirror/state": "6.2.0",
-    "@codemirror/view": "6.9.0",
-    "@lezer/common": "1.0.2",
-    "@lezer/generator": "1.2.2",
-    "@lezer/highlight": "1.1.3",
-    "@lezer/lr": "1.3.3",
+    "@codemirror/language": "6.7.0",
+    "@codemirror/lint": "6.2.2",
+    "@codemirror/search": "6.5.0",
+    "@codemirror/state": "6.2.1",
+    "@codemirror/view": "6.13.0",
+    "@lezer/common": "1.0.3",
+    "@lezer/generator": "1.2.3",
+    "@lezer/highlight": "1.1.6",
+    "@lezer/lr": "1.3.6",
     "@lezer/markdown": "1.0.2",
     "@nextjournal/lang-clojure": "1.0.0",
     "@nextjournal/lezer-clojure": "1.0.0",
@@ -33,9 +33,9 @@
     "punycode": "2.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "shadow-cljs": "2.20.14",
+    "shadow-cljs": "2.23.1",
     "use-sync-external-store": "1.2.0",
     "vh-sticky-table-header": "1.2.1",
-    "w3c-keyname": "2.2.6"
+    "w3c-keyname": "2.2.8"
   }
 }

--- a/src/jsxgraph/core.cljs
+++ b/src/jsxgraph/core.cljs
@@ -2,8 +2,8 @@
   "React/Reagent implementation of a component that exposes the API from
   http://jsxgraph.org/ in a more declarative way."
   (:require ["jsxgraph" :as jsx]
-            [reagent.core :as re]
-            ["react" :as react]))
+            ["react" :as react]
+            [reagent.core :as re]))
 
 ;; ## Utilities
 
@@ -14,16 +14,15 @@
   board-context
   (react/createContext nil))
 
-(def ^{:no-doc true
-       :doc "Use like
+(def ^:no-doc Provider
+  "Use like
 
-```clj
-[:> Provider {:value <board>} <children>]
-```
+  ```clj
+  [:> Provider {:value <board>} <children>]
+  ```
 
-to provide any element in `<children>` with access to the bound `board` instance
-  via `(react/useContext board-context)`."}
-  Provider
+  to provide any element in `<children>` with access to the bound `board` instance
+  via `(react/useContext board-context)`."
   (.-Provider board-context))
 
 (defn create
@@ -47,9 +46,7 @@ to provide any element in `<children>` with access to the bound `board` instance
                     (dissoc attributes "on")))]
     (when-let [m (attributes "on")]
       (doseq [[k f] m]
-        (let [callback (fn [_]
-                         (this-as elem
-                           (f elem)))]
+        (let [callback (fn [_] (f p))]
           (if (= k "update")
             (if-let [coords (.-coords p)]
               (.on coords "update" callback)
@@ -98,10 +95,8 @@ to provide any element in `<children>` with access to the bound `board` instance
 
 ;; ## Elements
 
-(def ^{:no-doc true
-       :doc "Map of element type to the actual Reagent component representing
-       that type."}
-  k->elem
+(def ^:no-doc k->elem
+  "Map of element type to the actual Reagent component representing that type."
   {"angle"                (element "angle")
    "arc"                  (element "arc")
    "arrow"                (element "arrow")
@@ -196,40 +191,41 @@ to provide any element in `<children>` with access to the bound `board` instance
 ;;
 ;; see `ElementType` in index.d.ts for the full list of valid elements.
 
-(def ^{:doc "Reagent component representing
+(def Angle
+  "Reagent component representing
   the [Angle](https://jsxgraph.org/docs/symbols/Angle.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Angle.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Angle
+  entry `:parents` with value containing the element's required parents."
   (k->elem "angle"))
 
-(def ^{:doc "Reagent component representing
-  the [Arc](https://jsxgraph.org/docs/symbols/Arc.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def Arc
+  "Reagent component representing
+  the [Arc](https://jsxgraph.org/docs/symbols/Arc.html) JSXGraph element. This
+  component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Arc.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Arc
+  entry `:parents` with value containing the element's required parents."
   (k->elem "arc"))
 
-(def ^{:doc "Reagent component representing
+(def Arrow
+  "Reagent component representing
   the [Arrow](https://jsxgraph.org/docs/symbols/Arrow.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Arrow.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Arrow
+  entry `:parents` with value containing the element's required parents."
   (k->elem "arrow"))
 
-(def ^{:doc "Reagent component representing
+(def ArrowParallel
+  "Reagent component representing
   the [ArrowParallel](https://jsxgraph.org/docs/symbols/ArrowParallel.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -238,68 +234,68 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/ArrowParallel.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  ArrowParallel
+  parents."
   (k->elem "arrowparallel"))
 
-(def ^{:doc "Reagent component representing
+(def Axis
+  "Reagent component representing
   the [Axis](https://jsxgraph.org/docs/symbols/Axis.html) JSXGraph element. This
   component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Axis.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Axis
+  entry `:parents` with value containing the element's required parents."
   (k->elem "axis"))
 
-(def ^{:doc "Reagent component representing
+(def Bisector
+  "Reagent component representing
   the [Bisector](https://jsxgraph.org/docs/symbols/Bisector.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Bisector.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
-
-  Bisector
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "bisector"))
 
-(def ^{:doc "Reagent component representing
-  the [Bisectorlines](https://jsxgraph.org/docs/symbols/Bisectorlines.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def Bisectorlines
+  "Reagent component representing
+  the [Bisectorlines](https://jsxgraph.org/docs/symbols/Bisectorlines.html)
+  JSXGraph element. This component must appear as a child of a [[JSXGraph]]
+  component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/Bisectorlines.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Bisectorlines
+  docs](https://jsxgraph.org/docs/symbols/Bisectorlines.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "bisectorlines"))
 
-(def ^{:doc "Reagent component representing
+(def Boxplot
+  "Reagent component representing
   the [Boxplot](https://jsxgraph.org/docs/symbols/Boxplot.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Boxplot.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-
-  Boxplot
+  entry `:parents` with value containing the element's required parents."
   (k->elem "boxplot"))
 
-(def ^{:doc "Reagent component representing
+(def Button
+  "Reagent component representing
   the [Button](https://jsxgraph.org/docs/symbols/Button.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Button.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Button
+  entry `:parents` with value containing the element's required parents."
   (k->elem "button"))
 
-(def ^{:doc "Reagent component representing
+(def CardinalSpline
+  "Reagent component representing
   the [CardinalSpline](https://jsxgraph.org/docs/symbols/CardinalSpline.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -308,45 +304,44 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/CardinalSpline.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  CardinalSpline
+  parents."
   (k->elem "cardinalspline"))
 
-(def ^{:doc "Reagent component representing
+(def Chart
+  "Reagent component representing
   the [Chart](https://jsxgraph.org/docs/symbols/Chart.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Chart.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Chart
+  entry `:parents` with value containing the element's required parents."
   (k->elem "chart"))
 
-(def ^{:doc "Reagent component representing
+(def Checkbox
+  "Reagent component representing
   the [Checkbox](https://jsxgraph.org/docs/symbols/Checkbox.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Checkbox.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
-
-  Checkbox
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "checkbox"))
 
-(def ^{:doc "Reagent component representing
+(def Circle
+  "Reagent component representing
   the [Circle](https://jsxgraph.org/docs/symbols/Circle.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Circle.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Circle
+  "
   (k->elem "circle"))
 
-(def ^{:doc "Reagent component representing
+(def Circumcenter
+  "Reagent component representing
   the [Circumcenter](https://jsxgraph.org/docs/symbols/Circumcenter.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -355,11 +350,11 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Circumcenter.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  Circumcenter
+  parents."
   (k->elem "circumcenter"))
 
-(def ^{:doc "Reagent component representing
+(def Circumcircle
+  "Reagent component representing
   the [Circumcircle](https://jsxgraph.org/docs/symbols/Circumcircle.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -368,11 +363,11 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Circumcircle.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  Circumcircle
+  parents."
   (k->elem "circumcircle"))
 
-(def ^{:doc "Reagent component representing
+(def CircumcircleArc
+  "Reagent component representing
   the [CircumcircleArc](https://jsxgraph.org/docs/symbols/CircumcircleArc.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -381,11 +376,11 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/CircumcircleArc.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  CircumcircleArc
+  parents."
   (k->elem "circumcirclearc"))
 
-(def ^{:doc "Reagent component representing
+(def CircumcircleSector
+  "Reagent component representing
   the [CircumcircleSector](https://jsxgraph.org/docs/symbols/CircumcircleSector.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -394,44 +389,44 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/CircumcircleSector.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  CircumcircleSector
+  parents."
   (k->elem "circumcirclesector"))
 
-(def ^{:doc "Reagent component representing
+(def Comb
+  "Reagent component representing
   the [Comb](https://jsxgraph.org/docs/symbols/Comb.html) JSXGraph element. This
   component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Comb.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Comb
+  entry `:parents` with value containing the element's required parents."
   (k->elem "comb"))
 
-(def ^{:doc "Reagent component representing
+(def Conic
+  "Reagent component representing
   the [Conic](https://jsxgraph.org/docs/symbols/Conic.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Conic.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Conic
+  entry `:parents` with value containing the element's required parents."
   (k->elem "conic"))
 
-(def ^{:doc "Reagent component representing
+(def Curve
+  "Reagent component representing
   the [Curve](https://jsxgraph.org/docs/symbols/Curve.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Curve.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Curve
+  entry `:parents` with value containing the element's required parents."
   (k->elem "curve"))
 
-(def ^{:doc "Reagent component representing
+(def CurveDifference
+  "Reagent component representing
   the [CurveDifference](https://jsxgraph.org/docs/symbols/CurveDifference.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -440,11 +435,11 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/CurveDifference.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  CurveDifference
+  parents."
   (k->elem "curvedifference"))
 
-(def ^{:doc "Reagent component representing
+(def CurveIntersection
+  "Reagent component representing
   the [CurveIntersection](https://jsxgraph.org/docs/symbols/CurveIntersection.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -453,57 +448,58 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/CurveIntersection.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  CurveIntersection
+  parents."
   (k->elem "curveintersection"))
 
-(def ^{:doc "Reagent component representing
+(def CurveUnion
+  "Reagent component representing
   the [CurveUnion](https://jsxgraph.org/docs/symbols/CurveUnion.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/CurveUnion.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
+  an entry `:parents` with value containing the element's required parents."
 
-  CurveUnion
   (k->elem "curveunion"))
 
-(def ^{:doc "Reagent component representing
-  the [Derivative](https://jsxgraph.org/docs/symbols/Derivative.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def Derivative
+  "Reagent component representing
+  the [Derivative](https://jsxgraph.org/docs/symbols/Derivative.html) JSXGraph
+  element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/Derivative.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Derivative
+  docs](https://jsxgraph.org/docs/symbols/Derivative.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "derivative"))
 
-(def ^{:doc "Reagent component representing
+(def Ellipse
+  "Reagent component representing
   the [Ellipse](https://jsxgraph.org/docs/symbols/Ellipse.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Ellipse.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-
-  Ellipse
+  entry `:parents` with value containing the element's required parents."
   (k->elem "ellipse"))
 
-(def ^{:doc "Reagent component representing
-  the [ForeignObject](https://jsxgraph.org/docs/symbols/ForeignObject.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def ForeignObject
+  "Reagent component representing
+  the [ForeignObject](https://jsxgraph.org/docs/symbols/ForeignObject.html)
+  JSXGraph element. This component must appear as a child of a [[JSXGraph]]
+  component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/ForeignObject.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  ForeignObject
+  docs](https://jsxgraph.org/docs/symbols/ForeignObject.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "foreignobject"))
 
-(def ^{:doc "Reagent component representing
+(def FunctionGraph
+  "Reagent component representing
   the [FunctionGraph](https://jsxgraph.org/docs/symbols/FunctionGraph.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -512,216 +508,213 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/FunctionGraph.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  FunctionGraph
+  parents."
   (k->elem "functiongraph"))
 
-(def ^{:doc "Reagent component representing
+(def Glider
+  "Reagent component representing
   the [Glider](https://jsxgraph.org/docs/symbols/Glider.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Glider.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-
-  Glider
+  entry `:parents` with value containing the element's required parents."
   (k->elem "glider"))
 
-(def ^{:doc "Reagent component representing
-  the [Grid](https://jsxgraph.org/docs/symbols/Grid.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def Grid
+  "Reagent component representing
+  the [Grid](https://jsxgraph.org/docs/symbols/Grid.html) JSXGraph element. This
+  component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Grid.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Grid
+  entry `:parents` with value containing the element's required parents."
   (k->elem "grid"))
 
-(def ^{:doc "Reagent component representing
+(def Group
+  "Reagent component representing
   the [Group](https://jsxgraph.org/docs/symbols/Group.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Group.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Group
+  entry `:parents` with value containing the element's required parents."
   (k->elem "group"))
 
-(def ^{:doc "Reagent component representing
+(def Hatch
+  "Reagent component representing
   the [Hatch](https://jsxgraph.org/docs/symbols/Hatch.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Hatch.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Hatch
+  entry `:parents` with value containing the element's required parents."
   (k->elem "hatch"))
 
-(def ^{:doc "Reagent component representing
+(def Hyperbola
+  "Reagent component representing
   the [Hyperbola](https://jsxgraph.org/docs/symbols/Hyperbola.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Hyperbola.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
-
-  Hyperbola
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "hyperbola"))
 
-(def ^{:doc "Reagent component representing
+(def Image
+  "Reagent component representing
   the [Image](https://jsxgraph.org/docs/symbols/Image.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Image.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Image
+  entry `:parents` with value containing the element's required parents."
   (k->elem "image"))
 
-(def ^{:doc "Reagent component representing
+(def Incenter
+  "Reagent component representing
   the [Incenter](https://jsxgraph.org/docs/symbols/Incenter.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Incenter.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
+  an entry `:parents` with value containing the element's required parents."
 
-  Incenter
   (k->elem "incenter"))
 
-(def ^{:doc "Reagent component representing
-  the [Incircle](https://jsxgraph.org/docs/symbols/Incircle.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def Incircle
+  "Reagent component representing
+  the [Incircle](https://jsxgraph.org/docs/symbols/Incircle.html) JSXGraph
+  element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/Incircle.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Incircle
+  docs](https://jsxgraph.org/docs/symbols/Incircle.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "incircle"))
 
-(def ^{:doc "Reagent component representing
+(def Inequality
+  "Reagent component representing
   the [Inequality](https://jsxgraph.org/docs/symbols/Inequality.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Inequality.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
-
-  Inequality
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "inequality"))
 
-(def ^{:doc "Reagent component representing
+(def Input
+  "Reagent component representing
   the [Input](https://jsxgraph.org/docs/symbols/Input.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Input.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Input
+  entry `:parents` with value containing the element's required parents."
   (k->elem "input"))
 
-(def ^{:doc "Reagent component representing
+(def Integral
+  "Reagent component representing
   the [Integral](https://jsxgraph.org/docs/symbols/Integral.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Integral.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
-
-  Integral
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "integral"))
 
-(def ^{:doc "Reagent component representing
-  the [Intersection](https://jsxgraph.org/docs/symbols/Intersection.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def Intersection
+  "Reagent component representing
+  the [Intersection](https://jsxgraph.org/docs/symbols/Intersection.html)
+  JSXGraph element. This component must appear as a child of a [[JSXGraph]]
+  component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/Intersection.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Intersection
+  docs](https://jsxgraph.org/docs/symbols/Intersection.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "intersection"))
 
-(def ^{:doc "Reagent component representing
+(def Label
+  "Reagent component representing
   the [Label](https://jsxgraph.org/docs/symbols/Label.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Label.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Label
+  entry `:parents` with value containing the element's required parents."
   (k->elem "label"))
 
-(def ^{:doc "Reagent component representing
+(def Legend
+  "Reagent component representing
   the [Legend](https://jsxgraph.org/docs/symbols/Legend.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Legend.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-
-  Legend
+  entry `:parents` with value containing the element's required parents."
   (k->elem "legend"))
 
-(def ^{:doc "Reagent component representing
-  the [Line](https://jsxgraph.org/docs/symbols/Line.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def Line
+  "Reagent component representing
+  the [Line](https://jsxgraph.org/docs/symbols/Line.html) JSXGraph element. This
+  component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Line.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Line
+  entry `:parents` with value containing the element's required parents."
   (k->elem "line"))
 
-(def ^{:doc "Reagent component representing
+(def Locus
+  "Reagent component representing
   the [Locus](https://jsxgraph.org/docs/symbols/Locus.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Locus.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Locus
+  entry `:parents` with value containing the element's required parents."
   (k->elem "locus"))
 
-(def ^{:doc "Reagent component representing
+(def MajorArc
+  "Reagent component representing
   the [MajorArc](https://jsxgraph.org/docs/symbols/MajorArc.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/MajorArc.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
-
-  MajorArc
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "majorarc"))
 
-(def ^{:doc "Reagent component representing
-  the [MajorSector](https://jsxgraph.org/docs/symbols/MajorSector.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def MajorSector
+  "Reagent component representing
+  the [MajorSector](https://jsxgraph.org/docs/symbols/MajorSector.html) JSXGraph
+  element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/MajorSector.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  MajorSector
+  docs](https://jsxgraph.org/docs/symbols/MajorSector.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "majorsector"))
 
-(def ^{:doc "Reagent component representing
+(def MetapostSpline
+  "Reagent component representing
   the [MetapostSpline](https://jsxgraph.org/docs/symbols/MetapostSpline.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -730,34 +723,34 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/MetapostSpline.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  MetapostSpline
+  parents."
   (k->elem "metapostspline"))
 
-(def ^{:doc "Reagent component representing
+(def Midpoint
+  "Reagent component representing
   the [Midpoint](https://jsxgraph.org/docs/symbols/Midpoint.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Midpoint.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
+  an entry `:parents` with value containing the element's required parents."
 
-  Midpoint
   (k->elem "midpoint"))
 
-(def ^{:doc "Reagent component representing
-  the [MinorArc](https://jsxgraph.org/docs/symbols/MinorArc.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def MinorArc
+  "Reagent component representing
+  the [MinorArc](https://jsxgraph.org/docs/symbols/MinorArc.html) JSXGraph
+  element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/MinorArc.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  MinorArc
+  docs](https://jsxgraph.org/docs/symbols/MinorArc.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "minorarc"))
 
-(def ^{:doc "Reagent component representing
+(def MinorSector
+  "Reagent component representing
   the [MinorSector](https://jsxgraph.org/docs/symbols/MinorSector.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
@@ -765,11 +758,11 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/MinorSector.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  MinorSector
+  parents."
   (k->elem "minorsector"))
 
-(def ^{:doc "Reagent component representing
+(def MirrorElement
+  "Reagent component representing
   the [MirrorElement](https://jsxgraph.org/docs/symbols/MirrorElement.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -778,11 +771,11 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/MirrorElement.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  MirrorElement
+  parents."
   (k->elem "mirrorelement"))
 
-(def ^{:doc "Reagent component representing
+(def MirrorPoint
+  "Reagent component representing
   the [MirrorPoint](https://jsxgraph.org/docs/symbols/MirrorPoint.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
@@ -790,11 +783,11 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/MirrorPoint.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  MirrorPoint
+  parents."
   (k->elem "mirrorpoint"))
 
-(def ^{:doc "Reagent component representing
+(def NonReflexAngle
+  "Reagent component representing
   the [NonReflexAngle](https://jsxgraph.org/docs/symbols/NonReflexAngle.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -803,34 +796,35 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/NonReflexAngle.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  NonReflexAngle
+  parents."
   (k->elem "nonreflexangle"))
 
-(def ^{:doc "Reagent component representing
+(def Normal
+  "Reagent component representing
   the [Normal](https://jsxgraph.org/docs/symbols/Normal.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Normal.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-
-  Normal
+  entry `:parents` with value containing the element's required parents."
   (k->elem "normal"))
 
-(def ^{:doc "Reagent component representing
-  the [OrthogonalProjection](https://jsxgraph.org/docs/symbols/OrthogonalProjection.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def OrthogonalProjection
+  "Reagent component representing
+  the [OrthogonalProjection](https://jsxgraph.org/docs/symbols/OrthogonalProjection.html)
+  JSXGraph element. This component must appear as a child of a [[JSXGraph]]
+  component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/OrthogonalProjection.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  OrthogonalProjection
+  docs](https://jsxgraph.org/docs/symbols/OrthogonalProjection.html), the map
+  must contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "orthogonalprojection"))
 
-(def ^{:doc "Reagent component representing
+(def OtherIntersection
+  "Reagent component representing
   the [OtherIntersection](https://jsxgraph.org/docs/symbols/OtherIntersection.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -839,34 +833,34 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/OtherIntersection.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  OtherIntersection
+  parents."
   (k->elem "otherintersection"))
 
-(def ^{:doc "Reagent component representing
+(def Parabola
+  "Reagent component representing
   the [Parabola](https://jsxgraph.org/docs/symbols/Parabola.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Parabola.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
+  an entry `:parents` with value containing the element's required parents."
 
-  Parabola
   (k->elem "parabola"))
 
-(def ^{:doc "Reagent component representing
-  the [Parallel](https://jsxgraph.org/docs/symbols/Parallel.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def Parallel
+  "Reagent component representing
+  the [Parallel](https://jsxgraph.org/docs/symbols/Parallel.html) JSXGraph
+  element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/Parallel.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Parallel
+  docs](https://jsxgraph.org/docs/symbols/Parallel.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "parallel"))
 
-(def ^{:doc "Reagent component representing
+(def ParallelPoint
+  "Reagent component representing
   the [ParallelPoint](https://jsxgraph.org/docs/symbols/ParallelPoint.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -875,11 +869,11 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/ParallelPoint.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  ParallelPoint
+  parents."
   (k->elem "parallelpoint"))
 
-(def ^{:doc "Reagent component representing
+(def Perpendicular
+  "Reagent component representing
   the [Perpendicular](https://jsxgraph.org/docs/symbols/Perpendicular.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -888,11 +882,11 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Perpendicular.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  Perpendicular
+  parents."
   (k->elem "perpendicular"))
 
-(def ^{:doc "Reagent component representing
+(def PerpendicularPoint
+  "Reagent component representing
   the [PerpendicularPoint](https://jsxgraph.org/docs/symbols/PerpendicularPoint.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -901,11 +895,11 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/PerpendicularPoint.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  PerpendicularPoint
+  parents."
   (k->elem "perpendicularpoint"))
 
-(def ^{:doc "Reagent component representing
+(def PerpendicularSegment
+  "Reagent component representing
   the [PerpendicularSegment](https://jsxgraph.org/docs/symbols/PerpendicularSegment.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -914,68 +908,69 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/PerpendicularSegment.html), the map
   must contain an entry `:parents` with value containing the element's required
-  parents."}
-  PerpendicularSegment
+  parents."
   (k->elem "perpendicularsegment"))
 
-(def ^{:doc "Reagent component representing
+(def Point
+  "Reagent component representing
   the [Point](https://jsxgraph.org/docs/symbols/Point.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Point.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Point
+  entry `:parents` with value containing the element's required parents."
   (k->elem "point"))
 
-(def ^{:doc "Reagent component representing
+(def PolarLine
+  "Reagent component representing
   the [PolarLine](https://jsxgraph.org/docs/symbols/PolarLine.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/PolarLine.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
-
-  PolarLine
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "polarline"))
 
-(def ^{:doc "Reagent component representing
-  the [PolePoint](https://jsxgraph.org/docs/symbols/PolePoint.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def PolePoint
+  "Reagent component representing
+  the [PolePoint](https://jsxgraph.org/docs/symbols/PolePoint.html) JSXGraph
+  element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/PolePoint.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  PolePoint
+  docs](https://jsxgraph.org/docs/symbols/PolePoint.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "polepoint"))
 
-(def ^{:doc "Reagent component representing
+(def Polygon
+  "Reagent component representing
   the [Polygon](https://jsxgraph.org/docs/symbols/Polygon.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Polygon.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
+  entry `:parents` with value containing the element's required parents."
 
-  Polygon
   (k->elem "polygon"))
 
-(def ^{:doc "Reagent component representing
-  the [PolygonalChain](https://jsxgraph.org/docs/symbols/PolygonalChain.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def PolygonalChain
+  "Reagent component representing
+  the [PolygonalChain](https://jsxgraph.org/docs/symbols/PolygonalChain.html)
+  JSXGraph element. This component must appear as a child of a [[JSXGraph]]
+  component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/PolygonalChain.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  PolygonalChain
+  docs](https://jsxgraph.org/docs/symbols/PolygonalChain.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "polygonalchain"))
 
-(def ^{:doc "Reagent component representing
+(def RadicalAxis
+  "Reagent component representing
   the [RadicalAxis](https://jsxgraph.org/docs/symbols/RadicalAxis.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
@@ -983,34 +978,35 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/RadicalAxis.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  RadicalAxis
+  parents."
   (k->elem "radicalaxis"))
 
-(def ^{:doc "Reagent component representing
+(def Reflection
+  "Reagent component representing
   the [Reflection](https://jsxgraph.org/docs/symbols/Reflection.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Reflection.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
+  an entry `:parents` with value containing the element's required parents."
 
-  Reflection
   (k->elem "reflection"))
 
-(def ^{:doc "Reagent component representing
-  the [ReflexAngle](https://jsxgraph.org/docs/symbols/ReflexAngle.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def ReflexAngle
+  "Reagent component representing
+  the [ReflexAngle](https://jsxgraph.org/docs/symbols/ReflexAngle.html) JSXGraph
+  element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/ReflexAngle.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  ReflexAngle
+  docs](https://jsxgraph.org/docs/symbols/ReflexAngle.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "reflexangle"))
 
-(def ^{:doc "Reagent component representing
+(def RegularPolygon
+  "Reagent component representing
   the [RegularPolygon](https://jsxgraph.org/docs/symbols/RegularPolygon.html)
   JSXGraph element. This component must appear as a child of a [[JSXGraph]]
   component.
@@ -1019,234 +1015,242 @@ to provide any element in `<children>` with access to the bound `board` instance
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/RegularPolygon.html), the map must
   contain an entry `:parents` with value containing the element's required
-  parents."}
-  RegularPolygon
+  parents."
   (k->elem "regularpolygon"))
 
-(def ^{:doc "Reagent component representing
+(def RiemannSum
+  "Reagent component representing
   the [RiemannSum](https://jsxgraph.org/docs/symbols/RiemannSum.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/RiemannSum.html), the map must contain
-  an entry `:parents` with value containing the element's required parents."}
-
-  RiemannSum
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "riemannsum"))
 
-(def ^{:doc "Reagent component representing
+(def Sector
+  "Reagent component representing
   the [Sector](https://jsxgraph.org/docs/symbols/Sector.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Sector.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Sector
+  entry `:parents` with value containing the element's required parents."
   (k->elem "sector"))
 
-(def ^{:doc "Reagent component representing
+(def Segment
+  "Reagent component representing
   the [Segment](https://jsxgraph.org/docs/symbols/Segment.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Segment.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-
-  Segment
+  entry `:parents` with value containing the element's required parents."
   (k->elem "segment"))
 
-(def ^{:doc "Reagent component representing
-  the [Semicircle](https://jsxgraph.org/docs/symbols/Semicircle.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def Semicircle
+  "Reagent component representing
+  the [Semicircle](https://jsxgraph.org/docs/symbols/Semicircle.html) JSXGraph
+  element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/Semicircle.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Semicircle
+  docs](https://jsxgraph.org/docs/symbols/Semicircle.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "semicircle"))
 
-(def ^{:doc "Reagent component representing
+(def Slider
+  "Reagent component representing
   the [Slider](https://jsxgraph.org/docs/symbols/Slider.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Slider.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
+  entry `:parents` with value containing the element's required parents."
 
-  Slider
   (k->elem "slider"))
 
-(def ^{:doc "Reagent component representing
-  the [SlopeTriangle](https://jsxgraph.org/docs/symbols/SlopeTriangle.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def SlopeTriangle
+  "Reagent component representing
+  the [SlopeTriangle](https://jsxgraph.org/docs/symbols/SlopeTriangle.html)
+  JSXGraph element. This component must appear as a child of a [[JSXGraph]]
+  component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/SlopeTriangle.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  SlopeTriangle
+  docs](https://jsxgraph.org/docs/symbols/SlopeTriangle.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "slopetriangle"))
 
-(def ^{:doc "Reagent component representing
+(def Spline
+  "Reagent component representing
   the [Spline](https://jsxgraph.org/docs/symbols/Spline.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Spline.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
+  entry `:parents` with value containing the element's required parents."
 
-  Spline
   (k->elem "spline"))
 
-(def ^{:doc "Reagent component representing
-  the [StepFunction](https://jsxgraph.org/docs/symbols/StepFunction.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def StepFunction
+  "Reagent component representing
+  the [StepFunction](https://jsxgraph.org/docs/symbols/StepFunction.html)
+  JSXGraph element. This component must appear as a child of a [[JSXGraph]]
+  component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/StepFunction.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  StepFunction
+  docs](https://jsxgraph.org/docs/symbols/StepFunction.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "stepfunction"))
 
-(def ^{:doc "Reagent component representing
+(def Tangent
+  "Reagent component representing
   the [Tangent](https://jsxgraph.org/docs/symbols/Tangent.html) JSXGraph
   element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Tangent.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Tangent
+  entry `:parents` with value containing the element's required parents."
   (k->elem "tangent"))
 
-(def ^{:doc "Reagent component representing
-  the [TapeMeasure](https://jsxgraph.org/docs/symbols/TapeMeasure.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def TapeMeasure
+  "Reagent component representing
+  the [TapeMeasure](https://jsxgraph.org/docs/symbols/TapeMeasure.html) JSXGraph
+  element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/TapeMeasure.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  TapeMeasure
+  docs](https://jsxgraph.org/docs/symbols/TapeMeasure.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "tapemeasure"))
 
-(def ^{:doc "Reagent component representing
-  the [Text](https://jsxgraph.org/docs/symbols/Text.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def Text
+  "Reagent component representing
+  the [Text](https://jsxgraph.org/docs/symbols/Text.html) JSXGraph element. This
+  component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Text.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Text
+  entry `:parents` with value containing the element's required parents."
   (k->elem "text"))
 
-(def ^{:doc "Reagent component representing
+(def Ticks
+  "Reagent component representing
   the [Ticks](https://jsxgraph.org/docs/symbols/Ticks.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Ticks.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Ticks
+  entry `:parents` with value containing the element's required parents."
   (k->elem "ticks"))
 
-(def ^{:doc "Reagent component representing
-  the [TraceCurve](https://jsxgraph.org/docs/symbols/TraceCurve.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def TraceCurve
+  "Reagent component representing
+  the [TraceCurve](https://jsxgraph.org/docs/symbols/TraceCurve.html) JSXGraph
+  element. This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/TraceCurve.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  TraceCurve
+  docs](https://jsxgraph.org/docs/symbols/TraceCurve.html), the map must contain
+  an entry `:parents` with value containing the element's required parents."
   (k->elem "tracecurve"))
 
-(def ^{:doc "Reagent component representing
-  the [Transformation](https://jsxgraph.org/docs/symbols/Transformation.html) JSXGraph element.
-  This component must appear as a child of a [[JSXGraph]] component.
+(def Transformation
+  "Reagent component representing
+  the [Transformation](https://jsxgraph.org/docs/symbols/Transformation.html)
+  JSXGraph element. This component must appear as a child of a [[JSXGraph]]
+  component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/Transformation.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Transformation
+  docs](https://jsxgraph.org/docs/symbols/Transformation.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "transformation"))
 
-(def ^{:doc "Reagent component representing
+(def Turtle
+  "Reagent component representing
   the [Turtle](https://jsxgraph.org/docs/symbols/Turtle.html) JSXGraph element.
   This component must appear as a child of a [[JSXGraph]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Turtle.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Turtle
+  entry `:parents` with value containing the element's required parents."
   (k->elem "turtle"))
 
 ;; ## 3D Components
 
-(def ^{:doc "Reagent component representing
-  the [Curve3D](https://jsxgraph.org/docs/symbols/Curve3D.html) JSXGraph element.
-  This component must appear as a child of a [[View3D]] component.
+(def Curve3D
+  "Reagent component representing
+  the [Curve3D](https://jsxgraph.org/docs/symbols/Curve3D.html) JSXGraph
+  element. This component must appear as a child of a [[View3D]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Curve3D.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Curve3D
+  entry `:parents` with value containing the element's required parents."
   (k->elem "Curve3d"))
 
-(def ^{:doc "Reagent component representing
-  the [FunctionGraph3D](https://jsxgraph.org/docs/symbols/FunctionGraph3D.html) JSXGraph element.
-  This component must appear as a child of a [[View3D]] component.
+(def FunctionGraph3D
+  "Reagent component representing
+  the [FunctionGraph3D](https://jsxgraph.org/docs/symbols/FunctionGraph3D.html)
+  JSXGraph element. This component must appear as a child of a [[View3D]]
+  component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/FunctionGraph3D.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  FunctionGraph3D
+  docs](https://jsxgraph.org/docs/symbols/FunctionGraph3D.html), the map must
+  contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "functiongraph3d"))
 
-(def ^{:doc "Reagent component representing
+(def Line3D
+  "Reagent component representing
   the [Line3D](https://jsxgraph.org/docs/symbols/Line3D.html) JSXGraph element.
   This component must appear as a child of a [[View3D]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Line3D.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Line3D
+  entry `:parents` with value containing the element's required parents."
   (k->elem "Line3d"))
 
-(def ^{:doc "Reagent component representing
-  the [ParametricSurface3D](https://jsxgraph.org/docs/symbols/ParametricSurface3D.html) JSXGraph element.
-  This component must appear as a child of a [[View3D]] component.
+(def ParametricSurface3D
+  "Reagent component representing
+  the [ParametricSurface3D](https://jsxgraph.org/docs/symbols/ParametricSurface3D.html)
+  JSXGraph element. This component must appear as a child of a [[View3D]]
+  component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
-  docs](https://jsxgraph.org/docs/symbols/ParametricSurface3D.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  ParametricSurface3D
+  docs](https://jsxgraph.org/docs/symbols/ParametricSurface3D.html), the map
+  must contain an entry `:parents` with value containing the element's required
+  parents."
   (k->elem "parametricsurface3d"))
 
-(def ^{:doc "Reagent component representing
-  the [Point3D](https://jsxgraph.org/docs/symbols/Point3D.html) JSXGraph element.
-  This component must appear as a child of a [[View3D]] component.
+(def Point3D
+  "Reagent component representing
+  the [Point3D](https://jsxgraph.org/docs/symbols/Point3D.html) JSXGraph
+  element. This component must appear as a child of a [[View3D]] component.
 
   The element takes a single map of attributes. In addition to the optional
   attributes specified in the [API
   docs](https://jsxgraph.org/docs/symbols/Point3D.html), the map must contain an
-  entry `:parents` with value containing the element's required parents."}
-  Point3D
+  entry `:parents` with value containing the element's required parents."
   (k->elem "point3d"))
 
 (defn ^:no-doc k->component [k]
@@ -1303,7 +1307,7 @@ to provide any element in `<children>` with access to the bound `board` instance
 
       :component-will-unmount
       (fn [this]
-        (swap! !board kill! re/props this))
+        (swap! !board kill! (re/props this)))
 
       :component-did-update
       (fn [this [_ p]]


### PR DESCRIPTION
- #34:

  - removes SCI-incompatible code from `jsxgraph.core` to allow JSXGraph.cljs
    use from Portal.

  - upgrades pieces of the local build (Clerk, kondo etc)